### PR TITLE
Support fetch data firstly from cache and then  from loader in one call

### DIFF
--- a/android/src/main/java/victoralbertos/io/android/MainActivity.java
+++ b/android/src/main/java/victoralbertos/io/android/MainActivity.java
@@ -2,20 +2,23 @@ package victoralbertos.io.android;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import io.rx_cache.DynamicKey;
+import io.rx_cache.Reply;
 import io.rx_cache.internal.RxCache;
 import rx.Observable;
+import rx.Subscriber;
 
 /**
  * Created by victor on 21/01/16.
  */
 public class MainActivity extends Activity {
 
-    @Override protected void onCreate(Bundle savedInstanceState) {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         //Create integration test for max mg limit and clearing expired data
@@ -25,10 +28,28 @@ public class MainActivity extends Activity {
                 .persistence(getApplicationContext().getFilesDir())
                 .using(RxProviders.class);
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 1; i++) {
             String key = System.currentTimeMillis() + i + "";
-            rxProviders.getMocksEphemeralPaginate(createObservableMocks(100), new DynamicKey(key))
-                    .subscribe();
+//            rxProviders.getMocksEphemeralPaginate(createObservableMocks(100), new DynamicKey(key))
+//                    .subscribe();
+
+            rxProviders.cacheThenLoader(createObservableMocks(1))
+                    .subscribe(new Subscriber<Reply<Mock>>() {
+                        @Override
+                        public void onCompleted() {
+                            Log.e("RxCache", "onComplete");
+                        }
+
+                        @Override
+                        public void onError(Throwable e) {
+                            Log.e("RxCache", "onError");
+                        }
+
+                        @Override
+                        public void onNext(Reply<Mock> mockReply) {
+                            Log.e("RxCache", "onNext: " + mockReply.getSource());
+                        }
+                    });
         }
     }
 

--- a/android/src/main/java/victoralbertos/io/android/RxProviders.java
+++ b/android/src/main/java/victoralbertos/io/android/RxProviders.java
@@ -3,8 +3,10 @@ package victoralbertos.io.android;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import io.rx_cache.CacheThenLoader;
 import io.rx_cache.DynamicKey;
 import io.rx_cache.LifeCache;
+import io.rx_cache.Reply;
 import rx.Observable;
 
 /**
@@ -17,5 +19,8 @@ public interface RxProviders {
 
     @LifeCache(duration = 1, timeUnit = TimeUnit.MILLISECONDS)
     Observable<List<MainActivity.Mock>> getMocksEphemeralPaginate(Observable<List<MainActivity.Mock>> mocks, DynamicKey page);
+
+    @CacheThenLoader
+    Observable<Reply<MainActivity.Mock>> cacheThenLoader(Observable<List<MainActivity.Mock>> loader);
 
 }

--- a/android/src/main/java/victoralbertos/io/android/RxProviders.java
+++ b/android/src/main/java/victoralbertos/io/android/RxProviders.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.rx_cache.CacheThenLoader;
 import io.rx_cache.DynamicKey;
+import io.rx_cache.ForceLoader;
 import io.rx_cache.LifeCache;
 import io.rx_cache.Reply;
 import rx.Observable;
@@ -23,4 +24,6 @@ public interface RxProviders {
     @CacheThenLoader
     Observable<Reply<MainActivity.Mock>> cacheThenLoader(Observable<List<MainActivity.Mock>> loader);
 
+    @ForceLoader
+    Observable<Reply<MainActivity.Mock>> forceLoader(Observable<List<MainActivity.Mock>> loader);
 }

--- a/rx_cache/src/main/java/io/rx_cache/CacheThenLoader.java
+++ b/rx_cache/src/main/java/io/rx_cache/CacheThenLoader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 jiangecho
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rx_cache;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * If set, RxCache will firstly load data from cache, then continue to load data from loader
+ * It means that your onNext maybe called multi-times with data from different source
+ * If not set, RxCache will only only the first valid data
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface CacheThenLoader {
+}

--- a/rx_cache/src/main/java/io/rx_cache/ForceLoader.java
+++ b/rx_cache/src/main/java/io/rx_cache/ForceLoader.java
@@ -23,9 +23,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * If set, RxCache will firstly load data from cache, then continue to load data from loader
- * It means that your onNext maybe called multi-times with data from different source
- * If not set, RxCache will only only the first valid data
+ * If set, the cache will be ignored, and RxCache will directly load data from loader
  */
 @Target(METHOD)
 @Retention(RUNTIME)

--- a/rx_cache/src/main/java/io/rx_cache/ForceLoader.java
+++ b/rx_cache/src/main/java/io/rx_cache/ForceLoader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 jiangecho
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rx_cache;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * If set, RxCache will firstly load data from cache, then continue to load data from loader
+ * It means that your onNext maybe called multi-times with data from different source
+ * If not set, RxCache will only only the first valid data
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface ForceLoader {
+}

--- a/rx_cache/src/main/java/io/rx_cache/internal/ProxyProviders.java
+++ b/rx_cache/src/main/java/io/rx_cache/internal/ProxyProviders.java
@@ -62,6 +62,17 @@ final class ProxyProviders implements InvocationHandler {
     }
 
     private Observable<Object> getData(final ProxyTranslator.ConfigProvider configProvider) {
+
+        if (configProvider.forceLoader()){
+            return getDataFromLoader(configProvider, null)
+                    .flatMap(new Func1<Reply, Observable<Object>>() {
+                        @Override
+                        public Observable<Object> call(Reply reply) {
+                            return Observable.just(getReturnType(configProvider, reply));
+                        }
+                    });
+        }
+
         return Observable.just(twoLayersCache.retrieve(configProvider.getProviderKey(), configProvider.getDynamicKey(), configProvider.getDynamicKeyGroup(), useExpiredDataIfLoaderNotAvailable, configProvider.getLifeTimeMillis()))
                 .map(new Func1<Record, Observable<Reply>>() {
                     @Override public Observable<Reply> call(final Record record) {

--- a/rx_cache/src/main/java/io/rx_cache/internal/ProxyProviders.java
+++ b/rx_cache/src/main/java/io/rx_cache/internal/ProxyProviders.java
@@ -65,8 +65,15 @@ final class ProxyProviders implements InvocationHandler {
         return Observable.just(twoLayersCache.retrieve(configProvider.getProviderKey(), configProvider.getDynamicKey(), configProvider.getDynamicKeyGroup(), useExpiredDataIfLoaderNotAvailable, configProvider.getLifeTimeMillis()))
                 .map(new Func1<Record, Observable<Reply>>() {
                     @Override public Observable<Reply> call(final Record record) {
-                        if (record != null && !configProvider.evictProvider().evict())
-                            return Observable.just(new Reply(record.getData(), record.getSource()));
+
+                        if (record != null && !configProvider.evictProvider().evict()) {
+                            if (configProvider.enableCacheThenLoader()) {
+                                Observable<Reply> cacheResponse = Observable.just(new Reply(record.getData(), record.getSource()));
+                                return Observable.concat(cacheResponse, getDataFromLoader(configProvider, record));
+                            } else {
+                                return Observable.just(new Reply(record.getData(), record.getSource()));
+                            }
+                        }
 
                         return getDataFromLoader(configProvider, record);
                     }

--- a/rx_cache/src/main/java/io/rx_cache/internal/ProxyTranslator.java
+++ b/rx_cache/src/main/java/io/rx_cache/internal/ProxyTranslator.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 
 import javax.inject.Inject;
 
+import io.rx_cache.CacheThenLoader;
 import io.rx_cache.DynamicKey;
 import io.rx_cache.DynamicKeyGroup;
 import io.rx_cache.EvictDynamicKey;
@@ -39,8 +40,7 @@ final class ProxyTranslator {
         this.method = method;
         this.objectsMethod = objectsMethod;
 
-        ConfigProvider configProvider = new ConfigProvider(getProviderKey(), getDynamicKey(), getDynamicKeyGroup(), getLoaderObservable(),
-                getLifeTimeCache(), requiredDetailResponse(), evictProvider());
+        ConfigProvider configProvider = new ConfigProvider(getProviderKey(), getDynamicKey(), getDynamicKeyGroup(), getLoaderObservable(), getLifeTimeCache(), requiredDetailResponse(), enableCacheThenLoader(), evictProvider());
         checkIntegrityConfiguration(configProvider);
 
         return configProvider;
@@ -77,6 +77,11 @@ final class ProxyTranslator {
         LifeCache lifeCache = method.getAnnotation(LifeCache.class);
         if (lifeCache == null) return 0;
         return lifeCache.timeUnit().toMillis(lifeCache.duration());
+    }
+
+    protected boolean enableCacheThenLoader(){
+        CacheThenLoader cacheThenLoader = method.getAnnotation(CacheThenLoader.class);
+        return cacheThenLoader != null ? true : false;
     }
 
     protected boolean requiredDetailResponse() {
@@ -132,6 +137,7 @@ final class ProxyTranslator {
         private final Observable loaderObservable;
         private final long lifeTime;
         private final boolean requiredDetailedResponse;
+        private boolean enableCacheThenLoader;
         private final EvictProvider evictProvider;
 
         ConfigProvider(String providerKey, String dynamicKey, String group, Observable loaderObservable, long lifeTime, boolean requiredDetailedResponse, EvictProvider evictProvider) {
@@ -142,6 +148,12 @@ final class ProxyTranslator {
             this.lifeTime = lifeTime;
             this.evictProvider = evictProvider;
             this.requiredDetailedResponse = requiredDetailedResponse;
+            this.enableCacheThenLoader = false;
+        }
+
+        ConfigProvider(String providerKey, String dynamicKey, String group, Observable loaderObservable, long lifeTime, boolean requiredDetailedResponse, boolean enableCacheThenLoader, EvictProvider evictProvider) {
+            this(providerKey, dynamicKey, group, loaderObservable, lifeTime, requiredDetailedResponse, evictProvider);
+            this.enableCacheThenLoader = enableCacheThenLoader;
         }
 
         String getProviderKey() {
@@ -162,6 +174,10 @@ final class ProxyTranslator {
 
         boolean requiredDetailedResponse() {
             return requiredDetailedResponse;
+        }
+
+        boolean enableCacheThenLoader(){
+            return enableCacheThenLoader;
         }
 
         Observable getLoaderObservable() {

--- a/rx_cache/src/main/java/io/rx_cache/internal/ProxyTranslator.java
+++ b/rx_cache/src/main/java/io/rx_cache/internal/ProxyTranslator.java
@@ -26,6 +26,7 @@ import io.rx_cache.DynamicKeyGroup;
 import io.rx_cache.EvictDynamicKey;
 import io.rx_cache.EvictDynamicKeyGroup;
 import io.rx_cache.EvictProvider;
+import io.rx_cache.ForceLoader;
 import io.rx_cache.LifeCache;
 import io.rx_cache.Reply;
 import rx.Observable;
@@ -40,7 +41,7 @@ final class ProxyTranslator {
         this.method = method;
         this.objectsMethod = objectsMethod;
 
-        ConfigProvider configProvider = new ConfigProvider(getProviderKey(), getDynamicKey(), getDynamicKeyGroup(), getLoaderObservable(), getLifeTimeCache(), requiredDetailResponse(), enableCacheThenLoader(), evictProvider());
+        ConfigProvider configProvider = new ConfigProvider(getProviderKey(), getDynamicKey(), getDynamicKeyGroup(), getLoaderObservable(), getLifeTimeCache(), requiredDetailResponse(), enableCacheThenLoader(), forceLoader(), evictProvider());
         checkIntegrityConfiguration(configProvider);
 
         return configProvider;
@@ -82,6 +83,11 @@ final class ProxyTranslator {
     protected boolean enableCacheThenLoader(){
         CacheThenLoader cacheThenLoader = method.getAnnotation(CacheThenLoader.class);
         return cacheThenLoader != null ? true : false;
+    }
+
+    private boolean forceLoader(){
+        ForceLoader forceLoader = method.getAnnotation(ForceLoader.class);
+        return forceLoader != null ? true : false;
     }
 
     protected boolean requiredDetailResponse() {
@@ -138,6 +144,7 @@ final class ProxyTranslator {
         private final long lifeTime;
         private final boolean requiredDetailedResponse;
         private boolean enableCacheThenLoader;
+        private boolean forceLoader;
         private final EvictProvider evictProvider;
 
         ConfigProvider(String providerKey, String dynamicKey, String group, Observable loaderObservable, long lifeTime, boolean requiredDetailedResponse, EvictProvider evictProvider) {
@@ -151,9 +158,10 @@ final class ProxyTranslator {
             this.enableCacheThenLoader = false;
         }
 
-        ConfigProvider(String providerKey, String dynamicKey, String group, Observable loaderObservable, long lifeTime, boolean requiredDetailedResponse, boolean enableCacheThenLoader, EvictProvider evictProvider) {
+        ConfigProvider(String providerKey, String dynamicKey, String group, Observable loaderObservable, long lifeTime, boolean requiredDetailedResponse, boolean enableCacheThenLoader, boolean forceLoader, EvictProvider evictProvider) {
             this(providerKey, dynamicKey, group, loaderObservable, lifeTime, requiredDetailedResponse, evictProvider);
             this.enableCacheThenLoader = enableCacheThenLoader;
+            this.forceLoader = forceLoader;
         }
 
         String getProviderKey() {
@@ -178,6 +186,10 @@ final class ProxyTranslator {
 
         boolean enableCacheThenLoader(){
             return enableCacheThenLoader;
+        }
+
+        boolean forceLoader(){
+            return forceLoader;
         }
 
         Observable getLoaderObservable() {


### PR DESCRIPTION
In some scenario: I need to fetch data firstly from local cache and then from loader in one call.
But please know that: two test cases failed, and I still not figure out the root cause.

failed test cases:
```
io.rx_cache.internal.ProxyProvidersTest > When_No_Reply_Then_Get_Mock FAILED
    java.lang.IndexOutOfBoundsException at ProxyProvidersTest.java:87

io.rx_cache.internal.ProxyProvidersTest > When_No_Evict_Cache_Then_Source_Retrieved_Is_Not_Cloud FAILED
    java.lang.IndexOutOfBoundsException at ProxyProvidersTest.java:80

80 tests completed, 2 failed
```