### PR TITLE
Made internal.ProxyProviders.RxCacheException static & depracated

### DIFF
--- a/core/src/main/java/io/rx_cache/internal/ProxyProviders.java
+++ b/core/src/main/java/io/rx_cache/internal/ProxyProviders.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import io.rx_cache.EvictDynamicKey;
 import io.rx_cache.EvictDynamicKeyGroup;
 import io.rx_cache.Reply;
+import io.rx_cache.RxCacheException;
 import io.rx_cache.Source;
 import io.rx_cache.internal.cache.EvictExpiredRecordsPersistence;
 import io.rx_cache.internal.cache.GetDeepCopy;
@@ -172,17 +173,5 @@ public final class ProxyProviders implements InvocationHandler {
         } else {
             return data;
         }
-    }
-
-    public class RxCacheException extends RuntimeException {
-
-        public RxCacheException(String message) {
-            super(message);
-        }
-
-        public RxCacheException(String message, Throwable exception) {
-            super(message, exception);
-        }
-
     }
 }

--- a/core/src/test/java/io/rx_cache/internal/migration/ProvidersRxCacheMigrations.java
+++ b/core/src/test/java/io/rx_cache/internal/migration/ProvidersRxCacheMigrations.java
@@ -8,9 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.rx_cache.Migration;
+import io.rx_cache.RxCacheException;
 import io.rx_cache.SchemeMigration;
 import io.rx_cache.internal.Jolyglot$;
-import io.rx_cache.internal.ProxyProviders;
 import io.rx_cache.internal.RxCache;
 import rx.Observable;
 import rx.observers.TestSubscriber;
@@ -37,7 +37,7 @@ public class ProvidersRxCacheMigrations {
         providersMigrations.getMocks(Observable.<List<Mock1>>just(null)).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         testSubscriber.assertNoValues();
-        testSubscriber.assertError(ProxyProviders.RxCacheException.class);
+        testSubscriber.assertError(RxCacheException.class);
     }
 
     private void populateMocks() {


### PR DESCRIPTION
As `io.rx_cache.internal.ProxyProviders.RxCacheException` is non-static there is no way to serialize it.

Additionally `ProxyProviders` throws probably wrong exception. It throws inner non-static `RxCacheException` instead of `io.rx_cache.RxCacheException` (which was nowhere used).

To be BC compatible, I've made `io.rx_cache.internal.ProxyProviders..RxCacheException` to extend `io.rx_cache.RxCacheException`. It should be delete in the next major or minor release (i.e. 2.0 or 1.6).

Changes:
- made `io.rx_cache.internal.ProxyProviders.RxCacheException` static
- added deprecation to `io.rx_cache.internal.ProxyProviders.RxCacheException` in flavour of `io.rx_cache.RxCacheException`
- `io.rx_cache.internal.ProxyProviders.RxCacheException` extends `io.rx_cache.RxCacheException` so there will not be BC break
- made `io.rx_cache.RxCacheException` not final to be able to extend it
