### PR TITLE
Fix Proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ The policy is very simple:
 ## Proguard
 ```
 -dontwarn io.rx_cache.internal.**
+-keepclassmembers enum io.rx_cache.Source { *; }
 ```
 
 


### PR DESCRIPTION
Without the modification, my app crashes at runtime because Proguard strips Source enum.