### PR TITLE
Update proguard rule on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Proguard users MUST add the two given lines to their proguard configuration file
 ```
 -dontwarn io.rx_cache2.internal.**
 -keepclassmembers enum io.rx_cache2.Source { *; }
+-keepclassmembernames class * { @io.rx_cache2.* <methods>; }
 ```
 
 


### PR DESCRIPTION
I got same crash at this issue : https://github.com/VictorAlbertos/RxCache/issues/85
and crash was solved after add this rule.
```
-keepclassmembernames class * { @io.rx_cache2.* <methods>; }
```