### PR TITLE
Rxcache should only throw `RxCacheException`.

### DIFF
--- a/core/src/main/java/io/rx_cache2/RxCacheException.java
+++ b/core/src/main/java/io/rx_cache2/RxCacheException.java
@@ -5,8 +5,16 @@ package io.rx_cache2;
  */
 public final class RxCacheException extends RuntimeException {
 
+  public RxCacheException() {
+    super();
+  }
+
   public RxCacheException(String message) {
     super(message);
+  }
+
+  public RxCacheException(Throwable throwable) {
+    super(throwable);
   }
 
   public RxCacheException(String message, Throwable exception) {

--- a/core/src/main/java/io/rx_cache2/internal/Disk.java
+++ b/core/src/main/java/io/rx_cache2/internal/Disk.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 
+import io.rx_cache2.RxCacheException;
 import io.rx_cache2.internal.encrypt.FileEncryptor;
 import io.victoralbertos.jolyglot.JolyglotGenerics;
 
@@ -128,7 +129,7 @@ public final class Disk implements Persistence {
         fileEncryptor.encrypt(encryptKey, new File(cacheDirectory, key));
       }
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new RxCacheException(e);
     } finally {
       try {
         if (fileWriter != null) {

--- a/runtime/src/main/java/io/rx_cache2/internal/ProxyProviders.java
+++ b/runtime/src/main/java/io/rx_cache2/internal/ProxyProviders.java
@@ -92,7 +92,7 @@ public final class ProxyProviders implements InvocationHandler {
         }
 
         String errorMessage = method.getName() + io.rx_cache2.internal.Locale.INVALID_RETURN_TYPE;
-        throw new RxCacheException(errorMessage);
+        return Observable.error(new RxCacheException(errorMessage));
       }
     }).blockingFirst();
   }

--- a/runtime/src/main/java/io/rx_cache2/internal/ProxyProviders.java
+++ b/runtime/src/main/java/io/rx_cache2/internal/ProxyProviders.java
@@ -16,6 +16,13 @@
 
 package io.rx_cache2.internal;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
@@ -24,13 +31,8 @@ import io.reactivex.Single;
 import io.rx_cache2.EncryptKey;
 import io.rx_cache2.Migration;
 import io.rx_cache2.MigrationCache;
+import io.rx_cache2.RxCacheException;
 import io.rx_cache2.SchemeMigration;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
 
 public final class ProxyProviders implements InvocationHandler {
   private final io.rx_cache2.internal.ProcessorProviders processorProviders;
@@ -90,7 +92,7 @@ public final class ProxyProviders implements InvocationHandler {
         }
 
         String errorMessage = method.getName() + io.rx_cache2.internal.Locale.INVALID_RETURN_TYPE;
-        throw new RuntimeException(errorMessage);
+        throw new RxCacheException(errorMessage);
       }
     }).blockingFirst();
   }


### PR DESCRIPTION
In doing so, the caller can handle exceptions more easily.