### PR TITLE
EvictProvider(true) can not evict all the data associated with the provider.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
   defaultConfig {
     applicationId "victoralbertos.io.android"
     minSdkVersion 16
-    targetSdkVersion 23
+    targetSdkVersion 22
     versionCode 1
     versionName "1.0"
   }
@@ -44,6 +44,27 @@ dependencies {
   annotationProcessor "com.google.dagger:dagger-compiler:2.14.1"
   compile "com.google.dagger:dagger:2.14.1"
   provided "org.glassfish:javax.annotation:10.0-b28"
+
+  implementation(rootProject.ext.dependencies["retrofit-converter-gson"]) {
+    exclude module: 'gson'
+    exclude module: 'okhttp'
+    exclude module: 'okio'
+    exclude module: 'retrofit'
+  }
+  implementation(rootProject.ext.dependencies["retrofit-adapter-rxjava2"]) {
+    exclude module: 'rxjava'
+    exclude module: 'okhttp'
+    exclude module: 'retrofit'
+    exclude module: 'okio'
+  }
+  api rootProject.ext.dependencies["okhttp3"]
+  api 'com.squareup.okhttp3:logging-interceptor:3.5.0'
+  api(rootProject.ext.dependencies["retrofit"]) {
+    exclude module: 'okhttp'
+    exclude module: 'okio'
+  }
+
+  api rootProject.ext.dependencies["rxandroid2"]
 }
 
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="victoralbertos.io.android">
-
+    <uses-permission android:name="android.permission.INTERNET"></uses-permission>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"></uses-permission>
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/android/src/main/java/victoralbertos/io/android/CommonCache.java
+++ b/android/src/main/java/victoralbertos/io/android/CommonCache.java
@@ -1,0 +1,17 @@
+package victoralbertos.io.android;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Observable;
+import io.rx_cache2.DynamicKey;
+import io.rx_cache2.EvictProvider;
+import io.rx_cache2.LifeCache;
+import io.rx_cache2.ProviderKey;
+import io.rx_cache2.Reply;
+
+public interface CommonCache {
+    @ProviderKey("mocks")
+    @LifeCache(duration = 2, timeUnit = TimeUnit.MINUTES)
+    Observable<Reply<List<User>>> getUsers(Observable<List<User>> users, DynamicKey idLastUserQueried, EvictProvider evictProvider);
+}

--- a/android/src/main/java/victoralbertos/io/android/MainActivity.java
+++ b/android/src/main/java/victoralbertos/io/android/MainActivity.java
@@ -1,10 +1,195 @@
 package victoralbertos.io.android;
 
 import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.google.gson.Gson;
+
+import java.io.File;
+import java.util.List;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+import io.reactivex.schedulers.Schedulers;
+import io.rx_cache2.DynamicKey;
+import io.rx_cache2.EvictProvider;
+import io.rx_cache2.Reply;
+import io.rx_cache2.internal.RxCache;
+import io.victoralbertos.jolyglot.GsonSpeaker;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
  * Created by victor on 21/01/16.
  */
+/**
+ * TODO reappear steps:
+ * monitor Paging request!
+ * 1.onclick PageReFresh btn;
+ * 2.onclick LoadMore btn:
+ * i get some log:
+ *
+ * 08-14 16:17:35.297 25835-25854/victoralbertos.io.android D/okhttp_getUsers: lastIdQueried:1,source:CLOUD
+ * 08-14 16:17:37.990 25835-25853/victoralbertos.io.android D/okhttp_getUsers: lastIdQueried:20,source:CLOUD (loadmore has no data.so request from cloud is normal)
+ *
+ * 3.onclick PageReFresh btn;
+ * according to descriptions from readme-- EvictProvider allows to explicitly evict all the data associated with the provider.
+ * so the loadmore should request from cloud no matter EvictProvider.evict is true or no.
+ *
+ * but there are logs after onclick loadmore btn:
+ * D/okhttp_getUsers: lastIdQueried:20,source:PERSISTENCE
+ *
+ * so the is my pr reason.
+ *
+ * Thanks you read my pr!
+ * @param view
+ */
 public class MainActivity extends Activity {
+    String TAG="Rxtest";
+    private Providers mProvider;
+    private RxCache rxCache;
+    private int lastid=1;
+    private TextView mtv;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.layout);
+        mtv = (TextView) findViewById(R.id.tv);
+        HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor();
+        httpLoggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BASIC);//ouput request basic message
+        OkHttpClient.Builder builder = new OkHttpClient.Builder().addNetworkInterceptor(httpLoggingInterceptor);
+
+        Retrofit.Builder client = new Retrofit.Builder().baseUrl("https://api.github.com/").client(builder.build());
+        client.addConverterFactory(GsonConverterFactory.create(new Gson()));
+        client.addCallAdapterFactory(RxJava2CallAdapterFactory.create());
+        File cacheDir = getFilesDir();
+        new RxCache.Builder()
+                .persistence(cacheDir, new GsonSpeaker())
+                .using(Providers.class);
+        Retrofit mretrofit = client.build();
+        mProvider = mretrofit.create(Providers.class);
+
+        rxCache = new RxCache.Builder().persistence(getCacheDir(), new GsonSpeaker(new Gson()));
+
+    }
+    public void ClearCache(View view){
+        getFilesDir().deleteOnExit();
+    }
+
+    public void PageReFresh(View view){
+        lastid=1;
+        Log.d(TAG, "PageReFresh: ");
+        Observable.just(mProvider.getUsers(lastid,10))
+                .flatMap(new Function<Observable<List<User>>, ObservableSource<List<User>>>() {
+            @Override
+            public ObservableSource<List<User>> apply(Observable<List<User>> listObservable) throws Exception {
+                return rxCache.using(CommonCache.class).getUsers(listObservable,new DynamicKey(lastid),new EvictProvider(true))
+                        .map(new Function<Reply<List<User>>, List<User>>() {
+                            @Override
+                            public List<User> apply(final Reply<List<User>> listReply) throws Exception {
+                                Log.d("okhttp_getUsers","lastIdQueried:"+lastid+",source:"+listReply.getSource());
+                                runOnUiThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        mtv.setText("lastIdQueried:"+lastid+",source:"+listReply.getSource());
+                                    }
+                                });
+
+                                return listReply.getData();
+                            }
+                        });
+            }
+        })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread()).subscribe(new Observer<List<User>>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onNext(List<User> users) {
+                lastid = users.get(users.size() - 1).getId();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                Log.d("okhttp_Requesterror",e.toString());
+
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+
+
+    }
+
+
+    public void LoadMore(View view){
+        if (lastid==1){
+            Toast.makeText(this,"Please onclick PageRefresh btn first",Toast.LENGTH_LONG).show();
+            return;
+        }
+        Log.d(TAG, "LoadMore: ");
+        Observable.just(mProvider.getUsers(lastid,10))
+                .flatMap(new Function<Observable<List<User>>, ObservableSource<List<User>>>() {
+                    @Override
+                    public ObservableSource<List<User>> apply(Observable<List<User>> listObservable) throws Exception {
+                        return rxCache.using(CommonCache.class).getUsers(listObservable,new DynamicKey(lastid),new EvictProvider(false))
+                                .map(new Function<Reply<List<User>>, List<User>>() {
+                                    @Override
+                                    public List<User> apply(final Reply<List<User>> listReply) throws Exception {
+                                        Log.d("okhttp_getUsers","lastIdQueried:"+lastid+",source:"+listReply.getSource());
+                                        runOnUiThread(new Runnable() {
+                                            @Override
+                                            public void run() {
+                                                mtv.setText("lastIdQueried:"+lastid+",source:"+listReply.getSource());
+                                            }
+                                        });
+                                        return listReply.getData();
+                                    }
+                                });
+                    }
+                })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread()).subscribe(new Observer<List<User>>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+
+            }
+
+            @Override
+            public void onNext(List<User> users) {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                Log.d("okhttp_Requesterror",e.toString());
+
+            }
+
+            @Override
+            public void onComplete() {
+
+            }
+        });
+    }
 
 }

--- a/android/src/main/java/victoralbertos/io/android/Providers.java
+++ b/android/src/main/java/victoralbertos/io/android/Providers.java
@@ -1,0 +1,16 @@
+package victoralbertos.io.android;
+
+import java.util.List;
+
+import io.reactivex.Observable;
+import retrofit2.http.GET;
+import retrofit2.http.Headers;
+import retrofit2.http.Query;
+
+public interface Providers {
+    String HEADER_API_VERSION = "Accept: application/vnd.github.v3+json";
+
+    @Headers({HEADER_API_VERSION})
+    @GET("/users")
+    Observable<List<User>> getUsers(@Query("since") int lastIdQueried, @Query("per_page") int perPage);
+}

--- a/android/src/main/java/victoralbertos/io/android/User.java
+++ b/android/src/main/java/victoralbertos/io/android/User.java
@@ -1,0 +1,30 @@
+package victoralbertos.io.android;
+
+public class User {
+    private final int id;
+    private final String login;
+    private final String avatar_url;
+
+    public User(int id, String login, String avatar_url) {
+        this.id = id;
+        this.login = login;
+        this.avatar_url = avatar_url;
+    }
+
+    public String getAvatarUrl() {
+        if (avatar_url.isEmpty()) return avatar_url;
+        return avatar_url.split("\\?")[0];
+    }
+
+
+    public int getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    @Override public String toString() {
+        return "id -> " + id + " login -> " + login;
+    }}

--- a/android/src/main/res/layout/layout.xml
+++ b/android/src/main/res/layout/layout.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <Button
+        android:text="PageReFresh"
+        android:onClick="PageReFresh"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+    <Button
+        android:text="LoadMore"
+        android:onClick="LoadMore"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+    <Button
+        android:text="ClearCache"
+        android:onClick="ClearCache"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+    <TextView
+        android:id="@+id/tv"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+    </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
+apply from:"config.gradle"
 buildscript {
   repositories {
     jcenter()
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.0.1'
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
   }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
+    classpath 'com.android.tools.build:gradle:2.3.3'
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
   }

--- a/config.gradle
+++ b/config.gradle
@@ -1,0 +1,110 @@
+ext {
+
+    android = [
+               compileSdkVersion       : 28,
+               buildToolsVersion       : "28.0.3",
+               minSdkVersion           : 14,
+               targetSdkVersion        : 28,
+               versionCode             : 180,
+               versionName             : "2.5.0"
+    ]
+
+     version = [
+                   androidSupportSdkVersion: "28.0.0",
+                   retrofitSdkVersion      : "2.4.0",
+                   dagger2SdkVersion       : "2.19",
+                   glideSdkVersion         : "4.8.0",
+                   butterknifeSdkVersion   : "8.8.1",
+                   rxlifecycleSdkVersion   : "1.0",
+                   rxlifecycle2SdkVersion  : "2.2.2",
+                   espressoSdkVersion      : "3.0.1",
+                   canarySdkVersion        : "1.5.4"
+        ]
+
+    dependencies = [
+                //support
+                "appcompat-v7"             : "com.android.support:appcompat-v7:${version["androidSupportSdkVersion"]}",
+                "design"                   : "com.android.support:design:${version["androidSupportSdkVersion"]}",
+                "support-v4"               : "com.android.support:support-v4:${version["androidSupportSdkVersion"]}",
+                "cardview-v7"              : "com.android.support:cardview-v7:${version["androidSupportSdkVersion"]}",
+                "annotations"              : "com.android.support:support-annotations:${version["androidSupportSdkVersion"]}",
+                "recyclerview-v7"          : "com.android.support:recyclerview-v7:${version["androidSupportSdkVersion"]}",
+
+                //network
+                "retrofit"                 : "com.squareup.retrofit2:retrofit:${version["retrofitSdkVersion"]}",
+                "retrofit-converter-gson"  : "com.squareup.retrofit2:converter-gson:${version["retrofitSdkVersion"]}",
+                "retrofit-adapter-rxjava"  : "com.squareup.retrofit2:adapter-rxjava:${version["retrofitSdkVersion"]}",
+                "retrofit-adapter-rxjava2" : "com.squareup.retrofit2:adapter-rxjava2:${version["retrofitSdkVersion"]}",
+                "okhttp3"                  : "com.squareup.okhttp3:okhttp:3.11.0",
+                "okhttp-urlconnection"     : "com.squareup.okhttp:okhttp-urlconnection:2.0.0",
+                "glide"                    : "com.github.bumptech.glide:glide:${version["glideSdkVersion"]}",
+                "glide-compiler"           : "com.github.bumptech.glide:compiler:${version["glideSdkVersion"]}",
+                "glide-loader-okhttp3"     : "com.github.bumptech.glide:okhttp3-integration:${version["glideSdkVersion"]}",
+                "picasso"                  : "com.squareup.picasso:picasso:2.5.2",
+
+                //view
+                "autolayout"               : "com.zhy:autolayout:1.4.5",
+                "butterknife"              : "com.jakewharton:butterknife:${version["butterknifeSdkVersion"]}",
+                "butterknife-compiler"     : "com.jakewharton:butterknife-compiler:${version["butterknifeSdkVersion"]}",
+                "pickerview"               : "com.contrarywind:Android-PickerView:3.2.5",
+                "photoview"                : "com.github.chrisbanes.photoview:library:1.2.3",
+                "numberprogressbar"        : "com.daimajia.numberprogressbar:library:1.2@aar",
+                "nineoldandroids"          : "com.nineoldandroids:library:2.4.0",
+                "paginate"                 : "com.github.markomilos:paginate:0.5.1",
+                "vlayout"                  : "com.alibaba.android:vlayout:1.1.0@aar",
+                "autosize"                 : "me.jessyan:autosize:1.1.1",
+
+                //rx1
+                "rxandroid"                : "io.reactivex:rxandroid:1.2.1",
+                "rxjava"                   : "io.reactivex:rxjava:1.3.0",
+                "rxlifecycle"              : "com.trello:rxlifecycle:${version["rxlifecycleSdkVersion"]}",
+                "rxlifecycle-components"   : "com.trello:rxlifecycle-components:${version["rxlifecycleSdkVersion"]}",
+                "rxcache"                  : "com.github.VictorAlbertos.RxCache:runtime:1.7.0-1.x",
+                "rxcache-jolyglot-gson"    : "com.github.VictorAlbertos.Jolyglot:gson:0.0.4",
+                "rxbinding-recyclerview-v7": "com.jakewharton.rxbinding:rxbinding-recyclerview-v7:1.0.1",
+                "rxpermissions"            : "com.tbruyelle.rxpermissions:rxpermissions:0.9.4@aar",
+                "rxerrorhandler"           : "me.jessyan:rxerrorhandler:1.0.1",
+
+                //rx2
+                "rxandroid2"               : "io.reactivex.rxjava2:rxandroid:2.1.0",
+                "rxjava2"                  : "io.reactivex.rxjava2:rxjava:2.2.3",
+                "rxlifecycle2"             : "com.trello.rxlifecycle2:rxlifecycle:${version["rxlifecycle2SdkVersion"]}",
+                "rxlifecycle2-android"     : "com.trello.rxlifecycle2:rxlifecycle-android:${version["rxlifecycle2SdkVersion"]}",
+                "rxlifecycle2-components"  : "com.trello.rxlifecycle2:rxlifecycle-components:${version["rxlifecycle2SdkVersion"]}",
+                "rxcache2"                 : "com.github.VictorAlbertos.RxCache:runtime:1.8.3-2.x",
+                "rxpermissions2"           : "com.github.tbruyelle:rxpermissions:0.10.2",
+                "rxerrorhandler2"          : "me.jessyan:rxerrorhandler:2.1.1",
+
+                //tools
+                "dagger2"                  : "com.google.dagger:dagger:${version["dagger2SdkVersion"]}",
+                "dagger2-androi d"          : "com.google.dagger:dagger-android:${version["dagger2SdkVersion"]}",
+                "dagger2-android-support"  : "com.google.dagger:dagger-android-support:${version["dagger2SdkVersion"]}",
+                "dagger2-compiler"         : "com.google.dagger:dagger-compiler:${version["dagger2SdkVersion"]}",
+                "dagger2-android-processor": "com.google.dagger:dagger-android-processor:${version["dagger2SdkVersion"]}",
+                "androideventbus"          : "org.simple:androideventbus:1.0.5.1",
+                "eventbus"                 : "org.greenrobot:eventbus:3.1.1",
+                "otto"                     : "com.squareup:otto:1.3.8",
+                "gson"                     : "com.google.code.gson:gson:2.8.5",
+                "multidex"                 : "com.android.support:multidex:1.0.3",
+                "javax.annotation"         : "javax.annotation:jsr250-api:1.0",
+                "arouter"                  : "com.alibaba:arouter-api:1.3.1",
+                "arouter-compiler"         : "com.alibaba:arouter-compiler:1.1.4",
+                "progressmanager"          : "me.jessyan:progressmanager:1.5.0",
+                "retrofit-url-manager"     : "me.jessyan:retrofit-url-manager:1.4.0",
+                "lifecyclemodel"           : "me.jessyan:lifecyclemodel:1.0.1",
+
+                //test
+                "junit"                    : "junit:junit:4.12",
+                "androidJUnitRunner"       : "android.support.test.runner.AndroidJUnitRunner",
+                "runner"                   : "com.android.support.test:runner:1.0.1",
+                "espresso-core"            : "com.android.support.test.espresso:espresso-core:${version["espressoSdkVersion"]}",
+                "espresso-contrib"         : "com.android.support.test.espresso:espresso-contrib:${version["espressoSdkVersion"]}",
+                "espresso-intents"         : "com.android.support.test.espresso:espresso-intents:${version["espressoSdkVersion"]}",
+                "mockito-core"             : "org.mockito:mockito-core:1.+",
+                "timber"                   : "com.jakewharton.timber:timber:4.7.1",
+                "logger"                   : "com.orhanobut:logger:2.2.0",
+                "canary-debug"             : "com.squareup.leakcanary:leakcanary-android:${version["canarySdkVersion"]}",
+                "canary-release"           : "com.squareup.leakcanary:leakcanary-android-no-op:${version["canarySdkVersion"]}",
+                "umeng-analytics"          : "com.umeng.analytics:analytics:6.0.1"
+        ]
+}

--- a/core/src/main/java/io/rx_cache2/internal/Disk.java
+++ b/core/src/main/java/io/rx_cache2/internal/Disk.java
@@ -153,6 +153,26 @@ public final class Disk implements Persistence {
   }
 
   /**
+   * Delete the object previously saved that startwith key
+   *
+   * @param key 
+   */
+  @Override
+  public void evictStartwith(String key) {
+    key = safetyKey(key);
+    File[] files = cacheDirectory.listFiles();
+
+    if (null != files) {
+      for (File file : files) {
+        if (file != null&&file.getName().startsWith(key)){
+          file.delete();
+        }
+      }
+    }
+  }
+
+
+  /**
    * Delete all objects previously saved.
    */
   @Override public void evictAll() {

--- a/core/src/main/java/io/rx_cache2/internal/Persistence.java
+++ b/core/src/main/java/io/rx_cache2/internal/Persistence.java
@@ -52,6 +52,12 @@ public interface Persistence {
    * @param key The key associated with the object to be deleted from persistence
    */
   void evict(String key);
+  /**
+   * Delete the data file starts with its particular key
+   *
+   * @param key The key associated with the object to be deleted from persistence
+   */
+  void evictStartwith(String key);
 
   /**
    * Delete all the data

--- a/core/src/main/java/io/rx_cache2/internal/cache/EvictRecord.java
+++ b/core/src/main/java/io/rx_cache2/internal/cache/EvictRecord.java
@@ -34,8 +34,8 @@ public final class EvictRecord extends Action {
 
     for (String keyMatchingKeyProvider : keysMatchingKeyProvider) {
       memory.evict(keyMatchingKeyProvider);
-      persistence.evict(keyMatchingKeyProvider);
     }
+    persistence.evictStartwith(providerKey);
   }
 
   void evictRecordsMatchingDynamicKey(String providerKey, String dynamicKey) {


### PR DESCRIPTION
This is a reappear bug demo.
reappear steps: monitor Paging request!
 1.onClick PageReFresh btn;
 2.onClick LoadMore btn:
  i get some log:
``` 
 08-14 16:17:35.297 25835-25854/victoralbertos.io.android D/okhttp_getUsers: lastIdQueried:1,source:CLOUD
 08-14 16:17:37.990 25835-25853/victoralbertos.io.android D/okhttp_getUsers: lastIdQueried:20,source:CLOUD (loadmore has no data.so request from cloud is normal)
 ```
3.onClick PageReFresh btn;
according to descriptions from readme-- EvictProvider allows to explicitly evict all the data associated with the provider.
so the loadmore should request from cloud no matter EvictProvider.evict is true or no.
  but there are logs after onClick load more button:
``` 
D/okhttp_getUsers: lastIdQueried:20,source:PERSISTENCE
```
so the is my pr reason.
Thank you read my pr!