### PR TITLE
use AdvanceEncryptor to fix encrypting cache error

### DIFF
--- a/core/src/main/java/io/rx_cache2/internal/RxCacheModule.java
+++ b/core/src/main/java/io/rx_cache2/internal/RxCacheModule.java
@@ -20,6 +20,7 @@ import dagger.Module;
 import dagger.Provides;
 import io.rx_cache2.MigrationCache;
 import io.rx_cache2.internal.cache.memory.ReferenceMapMemory;
+import io.rx_cache2.internal.encrypt.AdvanceEncryptor;
 import io.rx_cache2.internal.encrypt.BuiltInEncryptor;
 import io.rx_cache2.internal.encrypt.Encryptor;
 import io.victoralbertos.jolyglot.JolyglotGenerics;
@@ -69,7 +70,7 @@ public final class RxCacheModule {
   }
 
   @Singleton @Provides Encryptor provideEncryptor() {
-    return new BuiltInEncryptor();
+    return new AdvanceEncryptor();
   }
 
   @Singleton @Provides String provideEncryptKey() {

--- a/core/src/main/java/io/rx_cache2/internal/encrypt/AdvanceEncryptor.java
+++ b/core/src/main/java/io/rx_cache2/internal/encrypt/AdvanceEncryptor.java
@@ -1,0 +1,172 @@
+package io.rx_cache2.internal.encrypt;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.security.SecureRandom;
+import java.security.spec.KeySpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * https://stackoverflow.com/questions/13433529/android-4-2-broke-my-encrypt-decrypt-code-and-the-provided-solutions-dont-work#
+ * <pre>
+ * PackageName: io.rx_cache2.internal.encrypt
+ * FileName: AdvanceEncryptor
+ * Author: Yinyh
+ * Date: 2019/9/25 10:34
+ * </pre>
+ */
+public class AdvanceEncryptor implements Encryptor {
+
+    private static final int ITERATION_COUNT = 100;
+    private static final int KEY_LENGTH = 256;
+    private static final String PBKDF2_DERIVATION_ALGORITHM = "PBKDF2WithHmacSHA1";
+    private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+    private static final int PKCS5_SALT_LENGTH = 32;
+    private static final String DELIMITER = "]";
+    private static final int FILE_BUF = 1024;
+    private static final SecureRandom random = new SecureRandom();
+
+    @Override
+    public void encrypt(String key, File decryptedFile, File encryptedFile) {
+        byte[] salt = generateSalt();
+        SecretKey secretKey = deriveKey(key, salt);
+        if (null == secretKey) return;
+        try {
+            Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+            byte[] iv = generateIv(cipher.getBlockSize());
+            IvParameterSpec ivParams = new IvParameterSpec(iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivParams);
+            CipherInputStream cis =
+                    new CipherInputStream(new FileInputStream(decryptedFile), cipher);
+            writeToEncrypt(cis, new FileOutputStream(encryptedFile), salt, iv);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void decrypt(String key, File encryptedFile, File decryptedFile) {
+        try {
+            String prefix = readKeyFromEncrypt(new FileInputStream(encryptedFile));
+            if (null == prefix) return;
+            String[] fields = prefix.split(DELIMITER);
+            if (fields.length < 2) return;
+            SecretKey secretKey = deriveKey(key, fromBase64(fields[0]));
+            Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+            IvParameterSpec ivParams = new IvParameterSpec(fromBase64(fields[1]));
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, ivParams);
+            CipherOutputStream cos =
+                    new CipherOutputStream(new FileOutputStream(decryptedFile), cipher);
+            long skipByte = (prefix + "\r\n").getBytes(Charset.forName("UTF-8")).length;
+            writeToDecrypt(new FileInputStream(encryptedFile), cos, skipByte);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void writeToEncrypt(InputStream origin, OutputStream encrypt, byte[] salt, byte[] iv) {
+        String prefix = toBase64(salt) + DELIMITER + toBase64(iv) + "\r\n";
+        byte[] buffer = new byte[FILE_BUF];
+        int numBytes;
+        try {
+            encrypt.write(prefix.getBytes(Charset.forName("UTF-8")));
+            while ((numBytes = origin.read(buffer, 0, buffer.length)) != -1) {
+                encrypt.write(buffer, 0, numBytes);
+            }
+            encrypt.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            close(origin);
+            close(encrypt);
+        }
+    }
+
+    private String readKeyFromEncrypt(InputStream encrypt) {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(encrypt));
+        String key = null;
+        try {
+            key = reader.readLine();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            close(encrypt);
+        }
+        return key;
+    }
+
+    private void writeToDecrypt(InputStream encrypt, OutputStream decrypt, long skip) {
+        byte[] buffer = new byte[FILE_BUF];
+        int numBytes;
+        try {
+            encrypt.skip(skip);
+            while (-1 != (numBytes = encrypt.read(buffer, 0, buffer.length))) {
+                decrypt.write(buffer, 0, numBytes);
+            }
+            decrypt.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            close(encrypt);
+            close(decrypt);
+        }
+    }
+
+    private void close(Closeable closeable) {
+        try {
+            if (null != closeable) {
+                closeable.close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static byte[] generateSalt() {
+        byte[] b = new byte[PKCS5_SALT_LENGTH];
+        random.nextBytes(b);
+        return b;
+    }
+
+    private static byte[] generateIv(int length) {
+        byte[] b = new byte[length];
+        random.nextBytes(b);
+        return b;
+    }
+
+    private static SecretKey deriveKey(String password, byte[] salt) {
+        try {
+            KeySpec keySpec = new PBEKeySpec(password.toCharArray(), salt, ITERATION_COUNT, KEY_LENGTH);
+            SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(PBKDF2_DERIVATION_ALGORITHM);
+            byte[] keyBytes = keyFactory.generateSecret(keySpec).getEncoded();
+            return new SecretKeySpec(keyBytes, "AES");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private static String toBase64(byte[] bytes) {
+        return Base64.encodeToString(bytes, Base64.NO_WRAP);
+    }
+
+    private static byte[] fromBase64(String base64) {
+        return Base64.decode(base64, Base64.NO_WRAP);
+    }
+}

--- a/core/src/main/java/io/rx_cache2/internal/encrypt/Base64.java
+++ b/core/src/main/java/io/rx_cache2/internal/encrypt/Base64.java
@@ -1,0 +1,725 @@
+package io.rx_cache2.internal.encrypt;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Utilities for encoding and decoding the Base64 representation of
+ * binary data.  See RFCs <a
+ * href="http://www.ietf.org/rfc/rfc2045.txt">2045</a> and <a
+ * href="http://www.ietf.org/rfc/rfc3548.txt">3548</a>.
+ */
+public class Base64 {
+    /**
+     * Default values for encoder/decoder flags.
+     */
+    public static final int DEFAULT = 0;
+
+    /**
+     * Encoder flag bit to omit the padding '=' characters at the end
+     * of the output (if any).
+     */
+    public static final int NO_PADDING = 1;
+
+    /**
+     * Encoder flag bit to omit all line terminators (i.e., the output
+     * will be on one long line).
+     */
+    public static final int NO_WRAP = 2;
+
+    /**
+     * Encoder flag bit to indicate lines should be terminated with a
+     * CRLF pair instead of just an LF.  Has no effect if {@code
+     * NO_WRAP} is specified as well.
+     */
+    public static final int CRLF = 4;
+
+    /**
+     * Encoder/decoder flag bit to indicate using the "URL and
+     * filename safe" variant of Base64 (see RFC 3548 section 4) where
+     * {@code -} and {@code _} are used in place of {@code +} and
+     * {@code /}.
+     */
+    public static final int URL_SAFE = 8;
+
+    /**
+     * Flag to pass to to indicate that it
+     * should not close the output stream it is wrapping when it
+     * itself is closed.
+     */
+    public static final int NO_CLOSE = 16;
+
+    //  --------------------------------------------------------
+    //  shared code
+    //  --------------------------------------------------------
+
+    /* package */ static abstract class Coder {
+        public byte[] output;
+        public int op;
+
+        /**
+         * Encode/decode another block of input data.  this.output is
+         * provided by the caller, and must be big enough to hold all
+         * the coded data.  On exit, this.opwill be set to the length
+         * of the coded data.
+         *
+         * @param finish true if this is the final call to process for
+         *        this object.  Will finalize the coder state and
+         *        include any final bytes in the output.
+         *
+         * @return true if the input so far is good; false if some
+         *         error has been detected in the input stream..
+         */
+        public abstract boolean process(byte[] input, int offset, int len, boolean finish);
+
+        /**
+         * @return the maximum number of bytes a call to process()
+         * could produce for the given number of input bytes.  This may
+         * be an overestimate.
+         */
+        public abstract int maxOutputSize(int len);
+    }
+
+    //  --------------------------------------------------------
+    //  decoding
+    //  --------------------------------------------------------
+
+    /**
+     * Decode the Base64-encoded data in input and return the data in
+     * a new byte array.
+     *
+     * <p>The padding '=' characters at the end are considered optional, but
+     * if any are present, there must be the correct number of them.
+     *
+     * @param str    the input String to decode, which is converted to
+     *               bytes using the default charset
+     * @param flags  controls certain features of the decoded output.
+     *               Pass {@code DEFAULT} to decode standard Base64.
+     *
+     * @throws IllegalArgumentException if the input contains
+     * incorrect padding
+     */
+    public static byte[] decode(String str, int flags) {
+        return decode(str.getBytes(), flags);
+    }
+
+    /**
+     * Decode the Base64-encoded data in input and return the data in
+     * a new byte array.
+     *
+     * <p>The padding '=' characters at the end are considered optional, but
+     * if any are present, there must be the correct number of them.
+     *
+     * @param input the input array to decode
+     * @param flags  controls certain features of the decoded output.
+     *               Pass {@code DEFAULT} to decode standard Base64.
+     *
+     * @throws IllegalArgumentException if the input contains
+     * incorrect padding
+     */
+    public static byte[] decode(byte[] input, int flags) {
+        return decode(input, 0, input.length, flags);
+    }
+
+    /**
+     * Decode the Base64-encoded data in input and return the data in
+     * a new byte array.
+     *
+     * <p>The padding '=' characters at the end are considered optional, but
+     * if any are present, there must be the correct number of them.
+     *
+     * @param input  the data to decode
+     * @param offset the position within the input array at which to start
+     * @param len    the number of bytes of input to decode
+     * @param flags  controls certain features of the decoded output.
+     *               Pass {@code DEFAULT} to decode standard Base64.
+     *
+     * @throws IllegalArgumentException if the input contains
+     * incorrect padding
+     */
+    public static byte[] decode(byte[] input, int offset, int len, int flags) {
+        // Allocate space for the most data the input could represent.
+        // (It could contain less if it contains whitespace, etc.)
+        Decoder decoder = new Decoder(flags, new byte[len*3/4]);
+
+        if (!decoder.process(input, offset, len, true)) {
+            throw new IllegalArgumentException("bad base-64");
+        }
+
+        // Maybe we got lucky and allocated exactly enough output space.
+        if (decoder.op == decoder.output.length) {
+            return decoder.output;
+        }
+
+        // Need to shorten the array, so allocate a new one of the
+        // right size and copy.
+        byte[] temp = new byte[decoder.op];
+        System.arraycopy(decoder.output, 0, temp, 0, decoder.op);
+        return temp;
+    }
+
+    /* package */ static class Decoder extends Coder {
+        /**
+         * Lookup table for turning bytes into their position in the
+         * Base64 alphabet.
+         */
+        private static final int DECODE[] = {
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
+                52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1, -1,
+                -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+                -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        };
+
+        /**
+         * Decode lookup table for the "web safe" variant (RFC 3548
+         * sec. 4) where - and _ replace + and /.
+         */
+        private static final int DECODE_WEBSAFE[] = {
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1,
+                52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1, -1,
+                -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, 63,
+                -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        };
+
+        /** Non-data values in the DECODE arrays. */
+        private static final int SKIP = -1;
+        private static final int EQUALS = -2;
+
+        /**
+         * States 0-3 are reading through the next input tuple.
+         * State 4 is having read one '=' and expecting exactly
+         * one more.
+         * State 5 is expecting no more data or padding characters
+         * in the input.
+         * State 6 is the error state; an error has been detected
+         * in the input and no future input can "fix" it.
+         */
+        private int state;   // state number (0 to 6)
+        private int value;
+
+        final private int[] alphabet;
+
+        public Decoder(int flags, byte[] output) {
+            this.output = output;
+
+            alphabet = ((flags & URL_SAFE) == 0) ? DECODE : DECODE_WEBSAFE;
+            state = 0;
+            value = 0;
+        }
+
+        /**
+         * @return an overestimate for the number of bytes {@code
+         * len} bytes could decode to.
+         */
+        public int maxOutputSize(int len) {
+            return len * 3/4 + 10;
+        }
+
+        /**
+         * Decode another block of input data.
+         *
+         * @return true if the state machine is still healthy.  false if
+         *         bad base-64 data has been detected in the input stream.
+         */
+        public boolean process(byte[] input, int offset, int len, boolean finish) {
+            if (this.state == 6) return false;
+
+            int p = offset;
+            len += offset;
+
+            // Using local variables makes the decoder about 12%
+            // faster than if we manipulate the member variables in
+            // the loop.  (Even alphabet makes a measurable
+            // difference, which is somewhat surprising to me since
+            // the member variable is final.)
+            int state = this.state;
+            int value = this.value;
+            int op = 0;
+            final byte[] output = this.output;
+            final int[] alphabet = this.alphabet;
+
+            while (p < len) {
+                // Try the fast path:  we're starting a new tuple and the
+                // next four bytes of the input stream are all data
+                // bytes.  This corresponds to going through states
+                // 0-1-2-3-0.  We expect to use this method for most of
+                // the data.
+                //
+                // If any of the next four bytes of input are non-data
+                // (whitespace, etc.), value will end up negative.  (All
+                // the non-data values in decode are small negative
+                // numbers, so shifting any of them up and or'ing them
+                // together will result in a value with its top bit set.)
+                //
+                // You can remove this whole block and the output should
+                // be the same, just slower.
+                if (state == 0) {
+                    while (p+4 <= len &&
+                            (value = ((alphabet[input[p] & 0xff] << 18) |
+                                    (alphabet[input[p+1] & 0xff] << 12) |
+                                    (alphabet[input[p+2] & 0xff] << 6) |
+                                    (alphabet[input[p+3] & 0xff]))) >= 0) {
+                        output[op+2] = (byte) value;
+                        output[op+1] = (byte) (value >> 8);
+                        output[op] = (byte) (value >> 16);
+                        op += 3;
+                        p += 4;
+                    }
+                    if (p >= len) break;
+                }
+
+                // The fast path isn't available -- either we've read a
+                // partial tuple, or the next four input bytes aren't all
+                // data, or whatever.  Fall back to the slower state
+                // machine implementation.
+
+                int d = alphabet[input[p++] & 0xff];
+
+                switch (state) {
+                    case 0:
+                        if (d >= 0) {
+                            value = d;
+                            ++state;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 1:
+                        if (d >= 0) {
+                            value = (value << 6) | d;
+                            ++state;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 2:
+                        if (d >= 0) {
+                            value = (value << 6) | d;
+                            ++state;
+                        } else if (d == EQUALS) {
+                            // Emit the last (partial) output tuple;
+                            // expect exactly one more padding character.
+                            output[op++] = (byte) (value >> 4);
+                            state = 4;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 3:
+                        if (d >= 0) {
+                            // Emit the output triple and return to state 0.
+                            value = (value << 6) | d;
+                            output[op+2] = (byte) value;
+                            output[op+1] = (byte) (value >> 8);
+                            output[op] = (byte) (value >> 16);
+                            op += 3;
+                            state = 0;
+                        } else if (d == EQUALS) {
+                            // Emit the last (partial) output tuple;
+                            // expect no further data or padding characters.
+                            output[op+1] = (byte) (value >> 2);
+                            output[op] = (byte) (value >> 10);
+                            op += 2;
+                            state = 5;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 4:
+                        if (d == EQUALS) {
+                            ++state;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 5:
+                        if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+                }
+            }
+
+            if (!finish) {
+                // We're out of input, but a future call could provide
+                // more.
+                this.state = state;
+                this.value = value;
+                this.op = op;
+                return true;
+            }
+
+            // Done reading input.  Now figure out where we are left in
+            // the state machine and finish up.
+
+            switch (state) {
+                case 0:
+                    // Output length is a multiple of three.  Fine.
+                    break;
+                case 1:
+                    // Read one extra input byte, which isn't enough to
+                    // make another output byte.  Illegal.
+                    this.state = 6;
+                    return false;
+                case 2:
+                    // Read two extra input bytes, enough to emit 1 more
+                    // output byte.  Fine.
+                    output[op++] = (byte) (value >> 4);
+                    break;
+                case 3:
+                    // Read three extra input bytes, enough to emit 2 more
+                    // output bytes.  Fine.
+                    output[op++] = (byte) (value >> 10);
+                    output[op++] = (byte) (value >> 2);
+                    break;
+                case 4:
+                    // Read one padding '=' when we expected 2.  Illegal.
+                    this.state = 6;
+                    return false;
+                case 5:
+                    // Read all the padding '='s we expected and no more.
+                    // Fine.
+                    break;
+            }
+
+            this.state = state;
+            this.op = op;
+            return true;
+        }
+    }
+
+    //  --------------------------------------------------------
+    //  encoding
+    //  --------------------------------------------------------
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * String with the result.
+     *
+     * @param input  the data to encode
+     * @param flags  controls certain features of the encoded output.
+     *               Passing {@code DEFAULT} results in output that
+     *               adheres to RFC 2045.
+     */
+    public static String encodeToString(byte[] input, int flags) {
+        try {
+            return new String(encode(input, flags), "US-ASCII");
+        } catch (UnsupportedEncodingException e) {
+            // US-ASCII is guaranteed to be available.
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * String with the result.
+     *
+     * @param input  the data to encode
+     * @param offset the position within the input array at which to
+     *               start
+     * @param len    the number of bytes of input to encode
+     * @param flags  controls certain features of the encoded output.
+     *               Passing {@code DEFAULT} results in output that
+     *               adheres to RFC 2045.
+     */
+    public static String encodeToString(byte[] input, int offset, int len, int flags) {
+        try {
+            return new String(encode(input, offset, len, flags), "US-ASCII");
+        } catch (UnsupportedEncodingException e) {
+            // US-ASCII is guaranteed to be available.
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * byte[] with the result.
+     *
+     * @param input  the data to encode
+     * @param flags  controls certain features of the encoded output.
+     *               Passing {@code DEFAULT} results in output that
+     *               adheres to RFC 2045.
+     */
+    public static byte[] encode(byte[] input, int flags) {
+        return encode(input, 0, input.length, flags);
+    }
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * byte[] with the result.
+     *
+     * @param input  the data to encode
+     * @param offset the position within the input array at which to
+     *               start
+     * @param len    the number of bytes of input to encode
+     * @param flags  controls certain features of the encoded output.
+     *               Passing {@code DEFAULT} results in output that
+     *               adheres to RFC 2045.
+     */
+    public static byte[] encode(byte[] input, int offset, int len, int flags) {
+        Encoder encoder = new Encoder(flags, null);
+
+        // Compute the exact length of the array we will produce.
+        int output_len = len / 3 * 4;
+
+        // Account for the tail of the data and the padding bytes, if any.
+        if (encoder.do_padding) {
+            if (len % 3 > 0) {
+                output_len += 4;
+            }
+        } else {
+            switch (len % 3) {
+                case 0: break;
+                case 1: output_len += 2; break;
+                case 2: output_len += 3; break;
+            }
+        }
+
+        // Account for the newlines, if any.
+        if (encoder.do_newline && len > 0) {
+            output_len += (((len-1) / (3 * Encoder.LINE_GROUPS)) + 1) *
+                    (encoder.do_cr ? 2 : 1);
+        }
+
+        encoder.output = new byte[output_len];
+        encoder.process(input, offset, len, true);
+
+        assert encoder.op == output_len;
+
+        return encoder.output;
+    }
+
+    /* package */ static class Encoder extends Coder {
+        /**
+         * Emit a new line every this many output tuples.  Corresponds to
+         * a 76-character line length (the maximum allowable according to
+         * <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>).
+         */
+        public static final int LINE_GROUPS = 19;
+
+        /**
+         * Lookup table for turning Base64 alphabet positions (6 bits)
+         * into output bytes.
+         */
+        private static final byte ENCODE[] = {
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/',
+        };
+
+        /**
+         * Lookup table for turning Base64 alphabet positions (6 bits)
+         * into output bytes.
+         */
+        private static final byte ENCODE_WEBSAFE[] = {
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_',
+        };
+
+        final private byte[] tail;
+        /* package */ int tailLen;
+        private int count;
+
+        final public boolean do_padding;
+        final public boolean do_newline;
+        final public boolean do_cr;
+        final private byte[] alphabet;
+
+        public Encoder(int flags, byte[] output) {
+            this.output = output;
+
+            do_padding = (flags & NO_PADDING) == 0;
+            do_newline = (flags & NO_WRAP) == 0;
+            do_cr = (flags & CRLF) != 0;
+            alphabet = ((flags & URL_SAFE) == 0) ? ENCODE : ENCODE_WEBSAFE;
+
+            tail = new byte[2];
+            tailLen = 0;
+
+            count = do_newline ? LINE_GROUPS : -1;
+        }
+
+        /**
+         * @return an overestimate for the number of bytes {@code
+         * len} bytes could encode to.
+         */
+        public int maxOutputSize(int len) {
+            return len * 8/5 + 10;
+        }
+
+        public boolean process(byte[] input, int offset, int len, boolean finish) {
+            // Using local variables makes the encoder about 9% faster.
+            final byte[] alphabet = this.alphabet;
+            final byte[] output = this.output;
+            int op = 0;
+            int count = this.count;
+
+            int p = offset;
+            len += offset;
+            int v = -1;
+
+            // First we need to concatenate the tail of the previous call
+            // with any input bytes available now and see if we can empty
+            // the tail.
+
+            switch (tailLen) {
+                case 0:
+                    // There was no tail.
+                    break;
+
+                case 1:
+                    if (p+2 <= len) {
+                        // A 1-byte tail with at least 2 bytes of
+                        // input available now.
+                        v = ((tail[0] & 0xff) << 16) |
+                                ((input[p++] & 0xff) << 8) |
+                                (input[p++] & 0xff);
+                        tailLen = 0;
+                    };
+                    break;
+
+                case 2:
+                    if (p+1 <= len) {
+                        // A 2-byte tail with at least 1 byte of input.
+                        v = ((tail[0] & 0xff) << 16) |
+                                ((tail[1] & 0xff) << 8) |
+                                (input[p++] & 0xff);
+                        tailLen = 0;
+                    }
+                    break;
+            }
+
+            if (v != -1) {
+                output[op++] = alphabet[(v >> 18) & 0x3f];
+                output[op++] = alphabet[(v >> 12) & 0x3f];
+                output[op++] = alphabet[(v >> 6) & 0x3f];
+                output[op++] = alphabet[v & 0x3f];
+                if (--count == 0) {
+                    if (do_cr) output[op++] = '\r';
+                    output[op++] = '\n';
+                    count = LINE_GROUPS;
+                }
+            }
+
+            // At this point either there is no tail, or there are fewer
+            // than 3 bytes of input available.
+
+            // The main loop, turning 3 input bytes into 4 output bytes on
+            // each iteration.
+            while (p+3 <= len) {
+                v = ((input[p] & 0xff) << 16) |
+                        ((input[p+1] & 0xff) << 8) |
+                        (input[p+2] & 0xff);
+                output[op] = alphabet[(v >> 18) & 0x3f];
+                output[op+1] = alphabet[(v >> 12) & 0x3f];
+                output[op+2] = alphabet[(v >> 6) & 0x3f];
+                output[op+3] = alphabet[v & 0x3f];
+                p += 3;
+                op += 4;
+                if (--count == 0) {
+                    if (do_cr) output[op++] = '\r';
+                    output[op++] = '\n';
+                    count = LINE_GROUPS;
+                }
+            }
+
+            if (finish) {
+                // Finish up the tail of the input.  Note that we need to
+                // consume any bytes in tail before any bytes
+                // remaining in input; there should be at most two bytes
+                // total.
+
+                if (p-tailLen == len-1) {
+                    int t = 0;
+                    v = ((tailLen > 0 ? tail[t++] : input[p++]) & 0xff) << 4;
+                    tailLen -= t;
+                    output[op++] = alphabet[(v >> 6) & 0x3f];
+                    output[op++] = alphabet[v & 0x3f];
+                    if (do_padding) {
+                        output[op++] = '=';
+                        output[op++] = '=';
+                    }
+                    if (do_newline) {
+                        if (do_cr) output[op++] = '\r';
+                        output[op++] = '\n';
+                    }
+                } else if (p-tailLen == len-2) {
+                    int t = 0;
+                    v = (((tailLen > 1 ? tail[t++] : input[p++]) & 0xff) << 10) |
+                            (((tailLen > 0 ? tail[t++] : input[p++]) & 0xff) << 2);
+                    tailLen -= t;
+                    output[op++] = alphabet[(v >> 12) & 0x3f];
+                    output[op++] = alphabet[(v >> 6) & 0x3f];
+                    output[op++] = alphabet[v & 0x3f];
+                    if (do_padding) {
+                        output[op++] = '=';
+                    }
+                    if (do_newline) {
+                        if (do_cr) output[op++] = '\r';
+                        output[op++] = '\n';
+                    }
+                } else if (do_newline && op > 0 && count != LINE_GROUPS) {
+                    if (do_cr) output[op++] = '\r';
+                    output[op++] = '\n';
+                }
+
+                assert tailLen == 0;
+                assert p == len;
+            } else {
+                // Save the leftovers in tail to be consumed on the next
+                // call to encodeInternal.
+
+                if (p == len-1) {
+                    tail[tailLen++] = input[p];
+                } else if (p == len-2) {
+                    tail[tailLen++] = input[p];
+                    tail[tailLen++] = input[p+1];
+                }
+            }
+
+            this.op = op;
+            this.count = count;
+
+            return true;
+        }
+    }
+
+    private Base64() { }   // don't instantiate
+}

--- a/core/src/test/java/io/rx_cache2/internal/encrypt/AdvanceEncryptorTest.java
+++ b/core/src/test/java/io/rx_cache2/internal/encrypt/AdvanceEncryptorTest.java
@@ -1,0 +1,169 @@
+package io.rx_cache2.internal.encrypt;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.MethodSorters;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * <pre>
+ * PackageName: io.rx_cache2.internal.encrypt
+ * FileName: AdvanceEncryptorTest
+ * Author: Yinyh
+ * Date: 2019/9/25 16:59
+ * </pre>
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class AdvanceEncryptorTest {
+    private static final String FILENAME_IN = "fileIn";
+    private static final String FILENAME_ENCRYPTED = "fileEncrypted";
+    private static final String FILENAME_OUT = "fileOut";
+    private Encryptor encryptor;
+    private static File fileIn, fileOut, fileEncrypted;
+    @ClassRule
+    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+
+    @Before
+    public void setUp() {
+        encryptor = new io.rx_cache2.internal.encrypt.AdvanceEncryptor();
+    }
+
+    @Test
+    public void _01_When_Encrypt_And_Decrypt_Then_Retrieve_Original_Content() {
+        fileIn = getFile(FILENAME_IN, "A Dummy Content");
+        fileOut = getFile(FILENAME_OUT);
+        fileEncrypted = getFile(FILENAME_ENCRYPTED);
+
+        encryptor.encrypt("key", fileIn, fileEncrypted);
+        encryptor.decrypt("key", fileEncrypted, fileOut);
+        assertEquals(getFileContent(fileIn), getFileContent(fileOut));
+    }
+
+    @Test public void _02_When_Encrypt_Then_Original_Content_Does_Not_Match() {
+        fileIn = getFile(FILENAME_IN, "A Dummy Content 2");
+        fileEncrypted = getFile(FILENAME_ENCRYPTED);
+
+        encryptor.encrypt("key2", fileIn, fileEncrypted);
+        assertNotEquals(getFileContent(fileIn), getFileContent(fileEncrypted));
+    }
+
+    @Test public void _03_When_Decrypt_Then_Original_Content_Does_Match() {
+        fileOut = getFile(FILENAME_OUT);
+
+        encryptor.decrypt("key2", fileEncrypted, fileOut);
+        assertEquals(getFileContent(fileIn), (getFileContent(fileOut)));
+    }
+
+    @Test public void _04_When_Decrypt_With_Other_Key_Then_Original_Content_Does_Not_Match() {
+        fileOut = getFile(FILENAME_OUT);
+
+        encryptor.decrypt("keyFail", fileEncrypted, fileOut);
+        assertNotEquals(getFileContent(fileIn), (getFileContent(fileOut)));
+    }
+
+    @Test public void _05_When_Decrypt_With_Original_Key_Then_Original_Content_Does_Match() {
+        fileOut = getFile(FILENAME_OUT);
+
+        encryptor.decrypt("key2", fileEncrypted, fileOut);
+        assertEquals(getFileContent(fileIn), (getFileContent(fileOut)));
+    }
+
+    @Test public void _06_When_Encrypt_And_Decrypt_With_Long_Key_Then_Retrieve_Original_Content() {
+        String key2048 = "[n(s4v7nf?~]k'bP$/m]tc.VYXN2;H@C<~qL[{?LX!s$#$(zMh&ec}2R9$n.Zp)2%c}chbfQ5;#[t@7J\".\\-a\\SnBZGMF/VLHmc/c5yZ-<;7n(Eb4xJE%{CXX\"&msz{fVdT2HJN7Hvf(Eh>{fc2M8,}\"z8/;Ycv(H~./Lq-Q`=`N]9_T$[WmQKnKYu$MLf$6&]V`>k.DaxEfFgeZ:`uwZ^p,42-%ekT\"ef`DG]mjhK>_.6dTM}p`kgeZ%B$$H^Pz$[5$^x()t'@k?F=DX',cHj~ag%yFCm?m>u>xN2-R.WWb{zcH6\\Qe63PA[w<?ssg,@hRXeN6h[*yqYA6`;]K2j=3Z_}Gg)Rpz$r@4+`Q3?uF'n/xP]K(va&tRB22^*]}\\m9H@]<SZ=\">G=y[fWBAJp^4%-J2ju_>^}K^?`9!(CU[W9s(Zgvkx*x)c'*/]7kKU@{&wh<@mQVk^M(e}F?_]sYBR;G/J_k>!LkzW2c-~#q75bbwZ}]K{;@yg`[%\\ksHwJb]ugxP]zUz73Ur7?'S-~4L`c+m/'Tu{b&#SYSDQ!nvWaeV6Z\\[~yD<^j7aV>/RK(&gS(g9x,EG+9%w}W5LE~vNYKQj3)SM%pQ;V;U3NB.Se\\qF9wc>_~=r)aQ'd7<,\\3Xmze^N=38c2{N\"dQQX;}-)C?b[GMWb2d(8:/4j*!<VW9wE~;[umE@Z2]Nz='7CrF3F(9W5rS;WmpL$R4ZAbBtG`3r!4U/HuA3V@t}-mkbnfmk7qmzcr\\F'fe-fWBVEx.F2Q37\\T:&$u,,~7HFx7HeHD<7~\\M@*S*L&2>N+'zBTes.6GW]mW&eQ&v,zE/9\"w2<Z`Ap?s]yCj@3W&~#nUgx3b%#@_V_ZHWxf8W6^g\\V#L+s@Ra8ug-U7D(gK;S*>_GT8($ZVjv?@BzVeyZqH\\7y?bX?ZZ[Aq3Km=Jr.(2SMgBVd$$T[Qq`mHdJVM>4FRcL{a,Yv\"3=&SVrP:_[Bpk?Wq4/ZSGG:/;PD$3;gEu~w?k/}/DQZm9T{p=4&F#.VG+;7~w\\.\\/]$wvUQ-38=Ejq+4He7:X&$ZN]F=GHM<^Ftw/pt/]L`>$&6^z(3p4MhHt&xu,Eem>}~bfn+^mBY<$RS}q:&n\\qZ[#&G^N6m\\j<U]k@63N$ThU65A&G_aN$a9-Tgp]CYH!vV'EG_5eqgH-WRRu!Q~@2nE93D\"N@<S7+32j-@{,mU{x#$#ZF'z6C+HQPPw/#]y'VPnqx=-cm9M^6Xh:\")wj*tS~ge@N>&a#->cGzkjDLH6#!55,7Z6+-UBF49=3N+u^CPG*>EsXk7'X{AELfD:pb`!D5v'=}G;7xSZ'&6~=Tp2v'V(UKM)b[Q+^+;{=#2+J*tA~!AH\"VbD;%8nd_S3,+Z]vzKQss5:\\tJ38B^&6*j@~[W_sLR5<!(aXz\"6%DJ8vr'3$:=\\Unf44PB5[?L%J'D)~P$$njSt.UDV5NM'm=EjNry:t{tg8Mn*6v@S@'?V!&_wxRUP3Fh`]uZg^\\E5H:9r#2(UWbnxfa7.,_@u;V,2(/9:JE_BZb`V59N/kq(K<tJz'~_H[k;c\"E#!j9G[M(=#vyt'K2hAMe?+WsA,cu,QVL9]EV&fW~&XNThRL][8#LpR`K?UDdqHY+\"G\"K(PLf@ew+^&rB9pn%q#9h[\\5hbj7WKVLr2V!&nG~<DKnL8H6McGUn3]q;%*:\"{^f\"C8w^&w8B$B,Q#J\\j{bN+Xqq.VJ>:m=LJ^_:2f,_:U7k!N^dH!D4p'Rj}#E)%rZwb,{%Tc@a!^f$Q=a]T((k^R^Gy.4us&;RhDaBZwd>`?p>-MU:/F;d>u`Z8YL_Rz`\\}`t8GzWfqYecrw3N@=]rXn6;*_<r;/_/yCjPTVFp{*nVmEDryDkf`_vU^~6?m-rGNnk9u)t(`hsw;2=^m,?+r}&Sw[&`qDUDvVv:<u2d2PRF^p?#kLz7\"\\*5Xf=RrTDM;Sj8>M}}5>4QBa=w)}M[%v9\\NEy%C6?m[WhSZVA3gztd^Ps;9%/__@xk\"5Je6?FbSn=V_:C{BRk%vqqE/ruFFqeDPrKYB\\r=Kag75M<y";
+        fileIn = getFile(FILENAME_IN, "A Dummy Content");
+        fileOut = getFile(FILENAME_OUT);
+        fileEncrypted = getFile(FILENAME_ENCRYPTED);
+
+        encryptor.encrypt(key2048, fileIn, fileEncrypted);
+        encryptor.decrypt(key2048, fileEncrypted, fileOut);
+        assertEquals(getFileContent(fileIn), getFileContent(fileOut));
+    }
+
+    @Test public void _07_When_Encrypt_And_Decrypt_With_Long_Key_And_Long_Content_Then_Retrieve_Original_Content() {
+        String key2048 = "[n(s4v7nf?~]k'bP$/m]tc.VYXN2;H@C<~qL[{?LX!s$#$(zMh&ec}2R9$n.Zp)2%c}chbfQ5;#[t@7J\".\\-a\\SnBZGMF/VLHmc/c5yZ-<;7n(Eb4xJE%{CXX\"&msz{fVdT2HJN7Hvf(Eh>{fc2M8,}\"z8/;Ycv(H~./Lq-Q`=`N]9_T$[WmQKnKYu$MLf$6&]V`>k.DaxEfFgeZ:`uwZ^p,42-%ekT\"ef`DG]mjhK>_.6dTM}p`kgeZ%B$$H^Pz$[5$^x()t'@k?F=DX',cHj~ag%yFCm?m>u>xN2-R.WWb{zcH6\\Qe63PA[w<?ssg,@hRXeN6h[*yqYA6`;]K2j=3Z_}Gg)Rpz$r@4+`Q3?uF'n/xP]K(va&tRB22^*]}\\m9H@]<SZ=\">G=y[fWBAJp^4%-J2ju_>^}K^?`9!(CU[W9s(Zgvkx*x)c'*/]7kKU@{&wh<@mQVk^M(e}F?_]sYBR;G/J_k>!LkzW2c-~#q75bbwZ}]K{;@yg`[%\\ksHwJb]ugxP]zUz73Ur7?'S-~4L`c+m/'Tu{b&#SYSDQ!nvWaeV6Z\\[~yD<^j7aV>/RK(&gS(g9x,EG+9%w}W5LE~vNYKQj3)SM%pQ;V;U3NB.Se\\qF9wc>_~=r)aQ'd7<,\\3Xmze^N=38c2{N\"dQQX;}-)C?b[GMWb2d(8:/4j*!<VW9wE~;[umE@Z2]Nz='7CrF3F(9W5rS;WmpL$R4ZAbBtG`3r!4U/HuA3V@t}-mkbnfmk7qmzcr\\F'fe-fWBVEx.F2Q37\\T:&$u,,~7HFx7HeHD<7~\\M@*S*L&2>N+'zBTes.6GW]mW&eQ&v,zE/9\"w2<Z`Ap?s]yCj@3W&~#nUgx3b%#@_V_ZHWxf8W6^g\\V#L+s@Ra8ug-U7D(gK;S*>_GT8($ZVjv?@BzVeyZqH\\7y?bX?ZZ[Aq3Km=Jr.(2SMgBVd$$T[Qq`mHdJVM>4FRcL{a,Yv\"3=&SVrP:_[Bpk?Wq4/ZSGG:/;PD$3;gEu~w?k/}/DQZm9T{p=4&F#.VG+;7~w\\.\\/]$wvUQ-38=Ejq+4He7:X&$ZN]F=GHM<^Ftw/pt/]L`>$&6^z(3p4MhHt&xu,Eem>}~bfn+^mBY<$RS}q:&n\\qZ[#&G^N6m\\j<U]k@63N$ThU65A&G_aN$a9-Tgp]CYH!vV'EG_5eqgH-WRRu!Q~@2nE93D\"N@<S7+32j-@{,mU{x#$#ZF'z6C+HQPPw/#]y'VPnqx=-cm9M^6Xh:\")wj*tS~ge@N>&a#->cGzkjDLH6#!55,7Z6+-UBF49=3N+u^CPG*>EsXk7'X{AELfD:pb`!D5v'=}G;7xSZ'&6~=Tp2v'V(UKM)b[Q+^+;{=#2+J*tA~!AH\"VbD;%8nd_S3,+Z]vzKQss5:\\tJ38B^&6*j@~[W_sLR5<!(aXz\"6%DJ8vr'3$:=\\Unf44PB5[?L%J'D)~P$$njSt.UDV5NM'm=EjNry:t{tg8Mn*6v@S@'?V!&_wxRUP3Fh`]uZg^\\E5H:9r#2(UWbnxfa7.,_@u;V,2(/9:JE_BZb`V59N/kq(K<tJz'~_H[k;c\"E#!j9G[M(=#vyt'K2hAMe?+WsA,cu,QVL9]EV&fW~&XNThRL][8#LpR`K?UDdqHY+\"G\"K(PLf@ew+^&rB9pn%q#9h[\\5hbj7WKVLr2V!&nG~<DKnL8H6McGUn3]q;%*:\"{^f\"C8w^&w8B$B,Q#J\\j{bN+Xqq.VJ>:m=LJ^_:2f,_:U7k!N^dH!D4p'Rj}#E)%rZwb,{%Tc@a!^f$Q=a]T((k^R^Gy.4us&;RhDaBZwd>`?p>-MU:/F;d>u`Z8YL_Rz`\\}`t8GzWfqYecrw3N@=]rXn6;*_<r;/_/yCjPTVFp{*nVmEDryDkf`_vU^~6?m-rGNnk9u)t(`hsw;2=^m,?+r}&Sw[&`qDUDvVv:<u2d2PRF^p?#kLz7\"\\*5Xf=RrTDM;Sj8>M}}5>4QBa=w)}M[%v9\\NEy%C6?m[WhSZVA3gztd^Ps;9%/__@xk\"5Je6?FbSn=V_:C{BRk%vqqE/ruFFqeDPrKYB\\r=Kag75M<y";
+        fileIn = getFile(FILENAME_IN, key2048, 10000);  // 20 Mb aprox
+        fileOut = getFile(FILENAME_OUT);
+        fileEncrypted = getFile(FILENAME_ENCRYPTED);
+
+        encryptor.encrypt(key2048, fileIn, fileEncrypted);
+        encryptor.decrypt(key2048, fileEncrypted, fileOut);
+        assertEquals(getFileContent(fileIn), getFileContent(fileOut));
+    }
+
+    private File getFile(String filename) {
+        return getFile(filename, "");
+    }
+
+    private File getFile(String filename, String content) {
+        return getFile(filename, content, 1);
+    }
+
+    private File getFile(String filename, String content, int iterations) {
+        File file = new File(temporaryFolder.getRoot().getAbsolutePath(), filename);
+        FileWriter fileWriter = null;
+
+        try {
+            fileWriter = new FileWriter(file, false);
+
+            for (int i = 0; i < iterations; i++) {
+                if (i == 0)
+                    fileWriter.write(content);
+                else
+                    fileWriter.append(content);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        } finally {
+            try {
+                if (fileWriter != null) {
+                    fileWriter.flush();
+                    fileWriter.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return file;
+    }
+
+    private String getFileContent(File file) {
+        StringBuilder builder = new StringBuilder();
+        BufferedReader reader = null;
+
+        try {
+            reader = new BufferedReader(new FileReader(file.getAbsoluteFile()));
+            String aux;
+
+            while ((aux = reader.readLine()) != null) {
+                builder.append(aux);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        } finally {
+            try {
+                if (reader != null) {
+                    reader.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
The RxCache interface methods always load from network when using @EncryptKey and @Encrypt. I thought that it must have an error when encrypting or decrypting the cache data, but when I run the [test file](https://github.com/VictorAlbertos/RxCache/blob/2.x/core/src/test/java/io/rx_cache2/internal/encrypt/BuiltInEncryptorTest.java), the result was all green. 
Thus I directly use the [Encryptor](https://github.com/VictorAlbertos/RxCache/blob/2.x/core/src/main/java/io/rx_cache2/internal/encrypt/BuiltInEncryptor.java) to encrypt and decrypt file in my testing android project, I found that the BuiltInEncryptor cannot decrypt the data.
Finally, I found some [information](https://stackoverflow.com/questions/13433529/android-4-2-broke-my-encrypt-decrypt-code-and-the-provided-solutions-dont-work#) about the encrypt method difference between java platform and android platform.
I replace the BuiltInEncryptor with [AdvanceEncryptor](https://github.com/ZDZN/RxCache/blob/2.x/core/src/main/java/io/rx_cache2/internal/encrypt/AdvanceEncryptor.java) in [RxCacheModule](https://github.com/VictorAlbertos/RxCache/blob/2.x/core/src/main/java/io/rx_cache2/internal/RxCacheModule.java), the new Encryptor can run the correct result on android platform and is also [tested](https://github.com/ZDZN/RxCache/blob/2.x/core/src/test/java/io/rx_cache2/internal/encrypt/AdvanceEncryptorTest.java) in java platform.
Now I uses my build in my android project and I hope this pull request can fix this bug.
Thank you for your nice library.
